### PR TITLE
Implement Predicates for easier advancement use

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ runs {
         // Recommended logging level for the console
         // You can set various levels here.
         // Please read: https://stackoverflow.com/questions/2031163/when-to-use-the-different-log-levels
-        systemProperty 'forge.logging.console.level', 'debug'
+        systemProperty 'forge.logging.console.level', 'info'
 
         modSource project.sourceSets.main
     }

--- a/src/main/java/ing/pipebomb/alphamericaadv/AlphamericaAdv.java
+++ b/src/main/java/ing/pipebomb/alphamericaadv/AlphamericaAdv.java
@@ -1,5 +1,8 @@
 package ing.pipebomb.alphamericaadv;
 
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType;
+import net.neoforged.neoforge.registries.DeferredRegister;
 import org.slf4j.Logger;
 
 import com.mojang.logging.LogUtils;
@@ -8,6 +11,8 @@ import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.common.Mod;
 
+import java.util.function.Supplier;
+
 // The value here should match an entry in the META-INF/neoforge.mods.toml file
 @Mod(AlphamericaAdv.MODID)
 public class AlphamericaAdv
@@ -15,13 +20,20 @@ public class AlphamericaAdv
     // Define mod id in a common place for everything to reference
     public static final String MODID = "alphamericaadv";
     // Directly reference a slf4j logger
-    private static final Logger LOGGER = LogUtils.getLogger();
+    public static final Logger LOGGER = LogUtils.getLogger();
+
+    public static final DeferredRegister<LootItemConditionType> LOOT_PREDICATE = DeferredRegister.create(BuiltInRegistries.LOOT_CONDITION_TYPE,MODID);
+
+    public static final Supplier<LootItemConditionType> DISTANCE_TO = LOOT_PREDICATE.register("distance_to", () -> new LootItemConditionType(DistanceCheck.CODEC));
 
     // The constructor for the mod class is the first code that is run when your mod is loaded.
     // FML will recognize some parameter types like IEventBus or ModContainer and pass them in automatically.
     public AlphamericaAdv(IEventBus modEventBus, ModContainer modContainer)
     {
         LOGGER.info("Advancements mod loaded");
-    }
 
+        LOOT_PREDICATE.register(modEventBus);
+
+        //NeoForge.EVENT_BUS.register(this);
+    }
 }

--- a/src/main/java/ing/pipebomb/alphamericaadv/AlphamericaAdv.java
+++ b/src/main/java/ing/pipebomb/alphamericaadv/AlphamericaAdv.java
@@ -1,7 +1,10 @@
 package ing.pipebomb.alphamericaadv;
 
+import ing.pipebomb.alphamericaadv.predicates.DistanceCheck;
+import ing.pipebomb.alphamericaadv.predicates.PolygonCheck;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType;
+import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.registries.DeferredRegister;
 import org.slf4j.Logger;
 
@@ -26,6 +29,8 @@ public class AlphamericaAdv
 
     public static final Supplier<LootItemConditionType> DISTANCE_TO = LOOT_PREDICATE.register("distance_to", () -> new LootItemConditionType(DistanceCheck.CODEC));
 
+    public static final Supplier<LootItemConditionType> IN_POLYGON = LOOT_PREDICATE.register("in_polygon", () -> new LootItemConditionType(PolygonCheck.CODEC));
+
     // The constructor for the mod class is the first code that is run when your mod is loaded.
     // FML will recognize some parameter types like IEventBus or ModContainer and pass them in automatically.
     public AlphamericaAdv(IEventBus modEventBus, ModContainer modContainer)
@@ -34,6 +39,6 @@ public class AlphamericaAdv
 
         LOOT_PREDICATE.register(modEventBus);
 
-        //NeoForge.EVENT_BUS.register(this);
+        NeoForge.EVENT_BUS.register(this);
     }
 }

--- a/src/main/java/ing/pipebomb/alphamericaadv/DistanceCheck.java
+++ b/src/main/java/ing/pipebomb/alphamericaadv/DistanceCheck.java
@@ -1,0 +1,46 @@
+package ing.pipebomb.alphamericaadv;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Vec3i;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.storage.loot.IntRange;
+import net.minecraft.world.level.storage.loot.LootContext;
+import net.minecraft.world.level.storage.loot.predicates.LootItemCondition;
+import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType;
+import net.minecraft.world.phys.Vec3;
+
+public record DistanceCheck(LootContext.EntityTarget entityTarget, BlockPos position, IntRange intRange) implements LootItemCondition {
+
+    private static final MapCodec<BlockPos> POSITION_CODEC = RecordCodecBuilder.mapCodec(
+            instance -> instance.group(
+                    Codec.INT.fieldOf("x").forGetter(Vec3i::getX),
+                    Codec.INT.optionalFieldOf("y", 0).forGetter(Vec3i::getY), // just like, completely unused
+                    Codec.INT.fieldOf("z").forGetter(Vec3i::getZ)
+            ).apply(instance,BlockPos::new)
+    );
+    public static final MapCodec<DistanceCheck> CODEC = RecordCodecBuilder.mapCodec(
+            instance -> instance.group(
+                    LootContext.EntityTarget.CODEC.fieldOf("entity").forGetter(DistanceCheck::entityTarget),
+                    POSITION_CODEC.forGetter(DistanceCheck::position),
+                    IntRange.CODEC.fieldOf("range").forGetter(DistanceCheck::intRange)
+            ).apply(instance,DistanceCheck::new)
+    );
+
+    @Override
+    public LootItemConditionType getType() {
+        return AlphamericaAdv.DISTANCE_TO.get();
+    }
+
+    @Override
+    public boolean test(LootContext lootContext) {
+        //AlphamericaAdv.LOGGER.info("TEST RAN");
+        Entity entity = lootContext.getParamOrNull(this.entityTarget.getParam());
+        if (entity == null) return false;
+        double dist = entity.position().distanceTo(Vec3.atLowerCornerOf(this.position.atY((int) entity.position().y)));
+        AlphamericaAdv.LOGGER.info(String.valueOf(dist));
+        return this.intRange.test(lootContext, (int) dist);
+    }
+}

--- a/src/main/java/ing/pipebomb/alphamericaadv/predicates/DistanceCheck.java
+++ b/src/main/java/ing/pipebomb/alphamericaadv/predicates/DistanceCheck.java
@@ -1,8 +1,9 @@
-package ing.pipebomb.alphamericaadv;
+package ing.pipebomb.alphamericaadv.predicates;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import ing.pipebomb.alphamericaadv.AlphamericaAdv;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Vec3i;
 import net.minecraft.world.entity.Entity;

--- a/src/main/java/ing/pipebomb/alphamericaadv/predicates/PolygonCheck.java
+++ b/src/main/java/ing/pipebomb/alphamericaadv/predicates/PolygonCheck.java
@@ -1,0 +1,60 @@
+package ing.pipebomb.alphamericaadv.predicates;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import ing.pipebomb.alphamericaadv.AlphamericaAdv;
+import net.minecraft.Util;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.storage.loot.LootContext;
+import net.minecraft.world.level.storage.loot.predicates.LootItemCondition;
+import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+public record PolygonCheck(LootContext.EntityTarget target, List<Point> points) implements LootItemCondition {
+
+    public static final MapCodec<PolygonCheck> CODEC = RecordCodecBuilder.mapCodec(
+            instance -> instance.group(
+                    LootContext.EntityTarget.CODEC.fieldOf("entity").forGetter(PolygonCheck::target),
+                    Point.CODEC.listOf().fieldOf("points").forGetter(PolygonCheck::points)
+            ).apply(instance, PolygonCheck::new));
+    @Override
+    public LootItemConditionType getType() {
+        return AlphamericaAdv.IN_POLYGON.get();
+    }
+
+    @Override
+    public boolean test(LootContext lootContext) {
+        Entity ent = lootContext.getParamOrNull(this.target.getParam());
+        if (ent == null) return false;
+//        for (PointPair i : this.points) {
+//            AlphamericaAdv.LOGGER.info("[{}, {}]",i.x,i.z);
+//        }
+        return testPointInPoly(new Point((int) ent.getX(),(int) ent.getZ()), points);
+    }
+
+    public boolean testPointInPoly(Point pT, List<Point> polygon) {
+        // This method does the ray-cast thing but with optimizations for 2d polygons
+        boolean inside = false;
+        for (int i = 0,j=polygon.size()-1;i < polygon.size(); j = i++) {
+            Point pI = polygon.get(i);
+            Point pJ = polygon.get(j);
+            if (
+                    ((pI.z > pT.z) != (pJ.z > pT.z))
+                    && (pT.x < (((pJ.x-pI.x)*(pT.z-pI.z))/(pJ.z-pI.z)) + pI.x)
+            ) {
+                inside = !inside;
+            }
+        }
+        return inside;
+    }
+
+    public record Point(int x, int z) {
+        public static final Codec<Point> CODEC = Codec.INT_STREAM.comapFlatMap(
+                intStream -> Util.fixedSize(intStream,2).map(ints -> new Point(ints[0],ints[1])),
+                p -> IntStream.of(p.x,p.z)
+        );
+    }
+}

--- a/src/main/resources/data/alphamericaadv/advancement/get_gold.json
+++ b/src/main/resources/data/alphamericaadv/advancement/get_gold.json
@@ -1,0 +1,37 @@
+{
+    "display": {
+        "icon": {
+            "id": "minecraft:gold_ingot"
+        },
+        "title": "Gold Rush!",
+        "description": "We're rich!",
+        "frame": "challenge",
+        "hidden": true
+    },
+    "parent": "alphamericaadv:root",
+    "criteria": {
+        "gold": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "slots": {
+                    "full": {
+                        "min": 5
+                    }
+                },
+                "items": [
+                    {
+                        "items": "minecraft:gold_ingot",
+                        "count": {
+                            "min": 64
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    "rewards": {
+        "loot": [
+            "alphamericaadv:lava_bucket"
+        ]
+    }
+}

--- a/src/main/resources/data/alphamericaadv/advancement/kill_llama.json
+++ b/src/main/resources/data/alphamericaadv/advancement/kill_llama.json
@@ -7,7 +7,7 @@
         "description": "i mean this is basically cycles 3.",
         "hidden": true
     },
-    "parent": "alphamericaadv:root",
+    "parent": "alphamericaadv:ride_llama",
     "criteria": {
         "kill": {
             "trigger": "minecraft:player_killed_entity",

--- a/src/main/resources/data/alphamericaadv/advancement/make_llama.json
+++ b/src/main/resources/data/alphamericaadv/advancement/make_llama.json
@@ -7,7 +7,7 @@
         "description": "the cycle continues...",
         "hidden": true
     },
-    "parent": "alphamericaadv:root",
+    "parent": "alphamericaadv:ride_llama",
     "criteria": {
         "SEX": {
             "trigger": "minecraft:bred_animals",

--- a/src/main/resources/data/alphamericaadv/advancement/pt_chicago.json
+++ b/src/main/resources/data/alphamericaadv/advancement/pt_chicago.json
@@ -1,0 +1,29 @@
+{
+    "display": {
+        "icon": {
+            "id": "minecraft:cocoa_beans"
+        },
+        "title": "The Windy City",
+        "description": "Visit Chicago",
+        "frame": "goal"
+    },
+    "parent": "alphamericaadv:root",
+    "criteria": {
+        "go_there": {
+            "trigger": "minecraft:location",
+            "conditions": {
+                "player": [
+                    {
+                        "condition": "alphamericaadv:distance_to",
+                        "entity": "this",
+                        "range": {
+                            "max": 30
+                        },
+                        "x": 200,
+                        "z": 200
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/src/main/resources/data/alphamericaadv/advancement/utah.json
+++ b/src/main/resources/data/alphamericaadv/advancement/utah.json
@@ -1,0 +1,32 @@
+{
+    "display": {
+        "icon": {
+            "id": "minecraft:acacia_leaves"
+        },
+        "title": "UTAH",
+        "description": "a",
+        "frame": "task"
+    },
+    "parent": "alphamericaadv:root",
+    "criteria": {
+        "test": {
+            "trigger": "minecraft:location",
+            "conditions": {
+                "player": [
+                    {
+                        "condition": "alphamericaadv:in_polygon",
+                        "entity": "this",
+                        "points": [
+                            [-1,5],
+                            [18,30],
+                            [67,20],
+                            [32,45],
+                            [2,52],
+                            [-15,31]
+                        ]
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/src/main/resources/data/alphamericaadv/loot_table/lava_bucket.json
+++ b/src/main/resources/data/alphamericaadv/loot_table/lava_bucket.json
@@ -1,0 +1,13 @@
+{
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "name": "minecraft:lava_bucket"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Implements 2 different predicates for checking where a player is for advancements.
1) Point-Radius checks for places like cities, where the shape is already basically circular
2) Polygon based checking, where the area a player needs to be in is a polygon, For "do x while in state" advancements and the like